### PR TITLE
Fix identation rule for switch identation

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,10 +42,7 @@ module.exports = {
       },
     ],
     "import/exports-last": "warn",
-    "indent": [
-      "error",
-      2
-    ],
+    "indent": ["error", 2, { "SwitchCase": 1 }],
     "max-lines": [
       "error",
       {


### PR DESCRIPTION
There is an issue with prettier and eslint when trying to add identation on a switch, this makes eslint to use the same configuration as prettier