### PR TITLE
feat: disable import/exports-last rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,7 +38,7 @@ module.exports = {
         'newlines-between': 'always-and-inside-groups',
       },
     ],
-    'import/exports-last': 'warn',
+    'import/exports-last': 'off',
     indent: ['error', 2, { SwitchCase: 1 }],
     'max-lines': [
       'error',


### PR DESCRIPTION
Disables eslint's `import/exports-last` based on [this document](https://3.basecamp.com/4930323/buckets/25097140/messages/4400387487).